### PR TITLE
Unify IfStatement and IfExpression, fix whitespace

### DIFF
--- a/src/parser/expression.js
+++ b/src/parser/expression.js
@@ -701,6 +701,11 @@ pp.parseExprAtom = function (refShorthandDefaultPos) {
         return isSafe ? this.parseSafeAwait(node) : this.parseAwait(node);
       }
 
+    case tt._else:
+      if (this.hasPlugin("lightscript")) {
+        this.unexpected(null, "Unmatched `else` (must match indentation of the line with `if`).");
+      }
+
     default:
       this.unexpected();
   }

--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -343,24 +343,13 @@ pp.parseFunctionStatement = function (node) {
   return this.parseFunction(node, true);
 };
 
+// overridden in LightScript
+
 pp.parseIfStatement = function (node) {
   this.next();
   node.test = this.parseParenExpression();
   node.consequent = this.parseStatement(false);
-
-  if (this.hasPlugin("lightscript") && this.match(tt._elif)) {
-    node.alternate = this.parseIfStatement(this.startNode());
-  } else {
-    if (this.eat(tt._else)) {
-      if (this.hasPlugin("lightscript") && this.isLineBreak()) {
-        this.unexpected(this.state.lastTokEnd, tt.colon);
-      }
-      node.alternate = this.parseStatement(false);
-    } else {
-      node.alternate = null;
-    }
-  }
-
+  node.alternate = this.eat(tt._else) ? this.parseStatement(false) : null;
   return this.finishNode(node, "IfStatement");
 };
 

--- a/src/parser/statement.js
+++ b/src/parser/statement.js
@@ -228,8 +228,16 @@ pp.parseDebuggerStatement = function (node) {
 pp.parseDoStatement = function (node) {
   this.next();
   this.state.labels.push(loopLabel);
+  let isWhiteBlock, indentLevel;
+  if (this.hasPlugin("lightscript") && this.match(tt.colon)) {
+    isWhiteBlock = true;
+    indentLevel = this.state.indentLevel;
+  }
   node.body = this.parseStatement(false);
   this.state.labels.pop();
+  if (this.hasPlugin("lightscript") && isWhiteBlock && this.state.indentLevel !== indentLevel) {
+    this.unexpected(null, "Mismatched indent.");
+  }
   this.expect(tt._while);
 
   // do-while can't use the lightscript-defined parseParenExpression

--- a/src/plugins/lightscript.js
+++ b/src/plugins/lightscript.js
@@ -389,9 +389,9 @@ pp.parseNamedArrowFromCallExpression = function (node, call) {
 // c/p parseIfStatement
 
 pp.parseIf = function (node, isExpression) {
+  const indentLevel = this.state.indentLevel;
   this.next();
   node.test = this.parseParenExpression();
-  const indentLevel = this.state.indentLevel;
 
   if (isExpression) {
     node.consequent = this.match(tt.braceL)

--- a/src/plugins/lightscript.js
+++ b/src/plugins/lightscript.js
@@ -521,6 +521,10 @@ export default function (instance) {
 
   instance.extend("parseParenExpression", function (inner) {
     return function () {
+      if (this.isLineBreak()) {
+        this.unexpected(this.state.lastTokEnd, "Illegal newline.");
+      }
+
       // parens are special here; they might be `if (x) -1` or `if (x < 1) and y: -1`
       if (this.match(tt.parenL)) {
         const state = this.state.clone();

--- a/test/fixtures/lightscript/auto-const/onecond-oneline-if-member/options.json
+++ b/test/fixtures/lightscript/auto-const/onecond-oneline-if-member/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Paren-free test expressions must be followed by braces or a colon. (2:15)"
+  "throws": "Illegal newline. (1:2)"
 }

--- a/test/fixtures/lightscript/if-expression/assign-else-bad-indent/actual.js
+++ b/test/fixtures/lightscript/if-expression/assign-else-bad-indent/actual.js
@@ -1,0 +1,4 @@
+x = if false:
+    1
+  else if true:
+    2

--- a/test/fixtures/lightscript/if-expression/assign-else-bad-indent/options.json
+++ b/test/fixtures/lightscript/if-expression/assign-else-bad-indent/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Unmatched `else` (must match indentation of the line with `if`). (3:2)"
+}

--- a/test/fixtures/lightscript/if-expression/braces-no-colon/options.json
+++ b/test/fixtures/lightscript/if-expression/braces-no-colon/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token, expected : (4:2)"
+  "throws": "Unexpected token, expected : (3:6)"
 }

--- a/test/fixtures/lightscript/if-expression/colon-no-colon/options.json
+++ b/test/fixtures/lightscript/if-expression/colon-no-colon/options.json
@@ -1,3 +1,3 @@
 {
-  "throws": "Unexpected token, expected : (4:2)"
+  "throws": "Unexpected token, expected : (3:4)"
 }

--- a/test/fixtures/lightscript/if-expression/colon-oneline/expected.json
+++ b/test/fixtures/lightscript/if-expression/colon-oneline/expected.json
@@ -1,0 +1,231 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 28,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 8
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 28,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 8
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 28,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 8
+          }
+        },
+        "kind": "const",
+        "extra": {
+          "implicit": true
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 0,
+            "end": 28,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 3,
+                "column": 8
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 0,
+              "end": 1,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 1
+                },
+                "identifierName": "y"
+              },
+              "name": "y"
+            },
+            "init": {
+              "type": "IfExpression",
+              "start": 4,
+              "end": 28,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 4
+                },
+                "end": {
+                  "line": 3,
+                  "column": 8
+                }
+              },
+              "test": {
+                "type": "BinaryExpression",
+                "start": 7,
+                "end": 12,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 12
+                  }
+                },
+                "left": {
+                  "type": "Identifier",
+                  "start": 7,
+                  "end": 8,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 8
+                    },
+                    "identifierName": "x"
+                  },
+                  "name": "x"
+                },
+                "operator": ">",
+                "right": {
+                  "type": "NumericLiteral",
+                  "start": 11,
+                  "end": 12,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 11
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 12
+                    }
+                  },
+                  "extra": {
+                    "rawValue": 1,
+                    "raw": "1"
+                  },
+                  "value": 1
+                }
+              },
+              "consequent": {
+                "type": "BlockStatement",
+                "start": 12,
+                "end": 19,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 12
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 5
+                  }
+                },
+                "body": [
+                  {
+                    "type": "ExpressionStatement",
+                    "start": 16,
+                    "end": 19,
+                    "loc": {
+                      "start": {
+                        "line": 2,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 5
+                      }
+                    },
+                    "expression": {
+                      "type": "StringLiteral",
+                      "start": 16,
+                      "end": 19,
+                      "loc": {
+                        "start": {
+                          "line": 2,
+                          "column": 2
+                        },
+                        "end": {
+                          "line": 2,
+                          "column": 5
+                        }
+                      },
+                      "extra": {
+                        "rawValue": "a",
+                        "raw": "'a'"
+                      },
+                      "value": "a"
+                    }
+                  }
+                ],
+                "directives": [],
+                "extra": {
+                  "curly": false
+                }
+              },
+              "alternate": {
+                "type": "StringLiteral",
+                "start": 25,
+                "end": 28,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 8
+                  }
+                },
+                "extra": {
+                  "rawValue": "b",
+                  "raw": "'b'"
+                },
+                "value": "b"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/lightscript/if-expression/colon-oneline/options.json
+++ b/test/fixtures/lightscript/if-expression/colon-oneline/options.json
@@ -1,3 +1,0 @@
-{
-  "throws": "Unexpected token, expected : (3:5)"
-}

--- a/test/fixtures/lightscript/paren-free/multiline-cond-else-parens/actual.js
+++ b/test/fixtures/lightscript/paren-free/multiline-cond-else-parens/actual.js
@@ -1,0 +1,5 @@
+if true
+and true:
+  x()
+else:
+  y()

--- a/test/fixtures/lightscript/paren-free/multiline-cond-else-parens/expected.json
+++ b/test/fixtures/lightscript/paren-free/multiline-cond-else-parens/expected.json
@@ -1,0 +1,235 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 35,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 5,
+      "column": 5
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 35,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 5,
+        "column": 5
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "IfStatement",
+        "start": 0,
+        "end": 35,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 5,
+            "column": 5
+          }
+        },
+        "test": {
+          "type": "LogicalExpression",
+          "start": 3,
+          "end": 16,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 3
+            },
+            "end": {
+              "line": 2,
+              "column": 8
+            }
+          },
+          "left": {
+            "type": "BooleanLiteral",
+            "start": 3,
+            "end": 7,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 3
+              },
+              "end": {
+                "line": 1,
+                "column": 7
+              }
+            },
+            "value": true
+          },
+          "operator": "&&",
+          "right": {
+            "type": "BooleanLiteral",
+            "start": 12,
+            "end": 16,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 4
+              },
+              "end": {
+                "line": 2,
+                "column": 8
+              }
+            },
+            "value": true
+          }
+        },
+        "consequent": {
+          "type": "BlockStatement",
+          "start": 16,
+          "end": 23,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 8
+            },
+            "end": {
+              "line": 3,
+              "column": 5
+            }
+          },
+          "body": [
+            {
+              "type": "ExpressionStatement",
+              "start": 20,
+              "end": 23,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 5
+                }
+              },
+              "expression": {
+                "type": "CallExpression",
+                "start": 20,
+                "end": 23,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 5
+                  }
+                },
+                "callee": {
+                  "type": "Identifier",
+                  "start": 20,
+                  "end": 21,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 3
+                    },
+                    "identifierName": "x"
+                  },
+                  "name": "x"
+                },
+                "arguments": []
+              }
+            }
+          ],
+          "directives": [],
+          "extra": {
+            "curly": false
+          }
+        },
+        "alternate": {
+          "type": "BlockStatement",
+          "start": 28,
+          "end": 35,
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 4
+            },
+            "end": {
+              "line": 5,
+              "column": 5
+            }
+          },
+          "body": [
+            {
+              "type": "ExpressionStatement",
+              "start": 32,
+              "end": 35,
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 2
+                },
+                "end": {
+                  "line": 5,
+                  "column": 5
+                }
+              },
+              "expression": {
+                "type": "CallExpression",
+                "start": 32,
+                "end": 35,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 5
+                  }
+                },
+                "callee": {
+                  "type": "Identifier",
+                  "start": 32,
+                  "end": 33,
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 3
+                    },
+                    "identifierName": "y"
+                  },
+                  "name": "y"
+                },
+                "arguments": []
+              }
+            }
+          ],
+          "directives": [],
+          "extra": {
+            "curly": false
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/lightscript/paren-free/multiline-cond-else-wrong-indent/actual.js
+++ b/test/fixtures/lightscript/paren-free/multiline-cond-else-wrong-indent/actual.js
@@ -1,0 +1,5 @@
+if true
+  and true:
+    x()
+  else:
+    y()

--- a/test/fixtures/lightscript/paren-free/multiline-cond-else-wrong-indent/options.json
+++ b/test/fixtures/lightscript/paren-free/multiline-cond-else-wrong-indent/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Unmatched `else` (must match indentation of the line with `if`). (4:2)"
+}

--- a/test/fixtures/lightscript/paren-free/multiline-cond-else/actual.js
+++ b/test/fixtures/lightscript/paren-free/multiline-cond-else/actual.js
@@ -1,0 +1,5 @@
+if true
+  and true:
+    x()
+else:
+  y()

--- a/test/fixtures/lightscript/paren-free/multiline-cond-else/expected.json
+++ b/test/fixtures/lightscript/paren-free/multiline-cond-else/expected.json
@@ -1,0 +1,235 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 39,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 5,
+      "column": 5
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 39,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 5,
+        "column": 5
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "IfStatement",
+        "start": 0,
+        "end": 39,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 5,
+            "column": 5
+          }
+        },
+        "test": {
+          "type": "LogicalExpression",
+          "start": 3,
+          "end": 18,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 3
+            },
+            "end": {
+              "line": 2,
+              "column": 10
+            }
+          },
+          "left": {
+            "type": "BooleanLiteral",
+            "start": 3,
+            "end": 7,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 3
+              },
+              "end": {
+                "line": 1,
+                "column": 7
+              }
+            },
+            "value": true
+          },
+          "operator": "&&",
+          "right": {
+            "type": "BooleanLiteral",
+            "start": 14,
+            "end": 18,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 6
+              },
+              "end": {
+                "line": 2,
+                "column": 10
+              }
+            },
+            "value": true
+          }
+        },
+        "consequent": {
+          "type": "BlockStatement",
+          "start": 18,
+          "end": 27,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 10
+            },
+            "end": {
+              "line": 3,
+              "column": 7
+            }
+          },
+          "body": [
+            {
+              "type": "ExpressionStatement",
+              "start": 24,
+              "end": 27,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 4
+                },
+                "end": {
+                  "line": 3,
+                  "column": 7
+                }
+              },
+              "expression": {
+                "type": "CallExpression",
+                "start": 24,
+                "end": 27,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 7
+                  }
+                },
+                "callee": {
+                  "type": "Identifier",
+                  "start": 24,
+                  "end": 25,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 4
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 5
+                    },
+                    "identifierName": "x"
+                  },
+                  "name": "x"
+                },
+                "arguments": []
+              }
+            }
+          ],
+          "directives": [],
+          "extra": {
+            "curly": false
+          }
+        },
+        "alternate": {
+          "type": "BlockStatement",
+          "start": 32,
+          "end": 39,
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 4
+            },
+            "end": {
+              "line": 5,
+              "column": 5
+            }
+          },
+          "body": [
+            {
+              "type": "ExpressionStatement",
+              "start": 36,
+              "end": 39,
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 2
+                },
+                "end": {
+                  "line": 5,
+                  "column": 5
+                }
+              },
+              "expression": {
+                "type": "CallExpression",
+                "start": 36,
+                "end": 39,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 5
+                  }
+                },
+                "callee": {
+                  "type": "Identifier",
+                  "start": 36,
+                  "end": 37,
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 3
+                    },
+                    "identifierName": "y"
+                  },
+                  "name": "y"
+                },
+                "arguments": []
+              }
+            }
+          ],
+          "directives": [],
+          "extra": {
+            "curly": false
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/lightscript/paren-free/multiline-cond-no-indent/actual.js
+++ b/test/fixtures/lightscript/paren-free/multiline-cond-no-indent/actual.js
@@ -1,0 +1,7 @@
+if (
+  true and
+  true
+):
+  x()
+else:
+  y()

--- a/test/fixtures/lightscript/paren-free/multiline-cond-no-indent/expected.json
+++ b/test/fixtures/lightscript/paren-free/multiline-cond-no-indent/expected.json
@@ -1,0 +1,236 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 43,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 7,
+      "column": 5
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 43,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 7,
+        "column": 5
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "IfStatement",
+        "start": 0,
+        "end": 43,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 7,
+            "column": 5
+          }
+        },
+        "test": {
+          "type": "LogicalExpression",
+          "start": 7,
+          "end": 22,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 2
+            },
+            "end": {
+              "line": 3,
+              "column": 6
+            }
+          },
+          "left": {
+            "type": "BooleanLiteral",
+            "start": 7,
+            "end": 11,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 2
+              },
+              "end": {
+                "line": 2,
+                "column": 6
+              }
+            },
+            "value": true
+          },
+          "operator": "&&",
+          "right": {
+            "type": "BooleanLiteral",
+            "start": 18,
+            "end": 22,
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 2
+              },
+              "end": {
+                "line": 3,
+                "column": 6
+              }
+            },
+            "value": true
+          },
+          "extra": {}
+        },
+        "consequent": {
+          "type": "BlockStatement",
+          "start": 24,
+          "end": 31,
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 1
+            },
+            "end": {
+              "line": 5,
+              "column": 5
+            }
+          },
+          "body": [
+            {
+              "type": "ExpressionStatement",
+              "start": 28,
+              "end": 31,
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 2
+                },
+                "end": {
+                  "line": 5,
+                  "column": 5
+                }
+              },
+              "expression": {
+                "type": "CallExpression",
+                "start": 28,
+                "end": 31,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 5
+                  }
+                },
+                "callee": {
+                  "type": "Identifier",
+                  "start": 28,
+                  "end": 29,
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 3
+                    },
+                    "identifierName": "x"
+                  },
+                  "name": "x"
+                },
+                "arguments": []
+              }
+            }
+          ],
+          "directives": [],
+          "extra": {
+            "curly": false
+          }
+        },
+        "alternate": {
+          "type": "BlockStatement",
+          "start": 36,
+          "end": 43,
+          "loc": {
+            "start": {
+              "line": 6,
+              "column": 4
+            },
+            "end": {
+              "line": 7,
+              "column": 5
+            }
+          },
+          "body": [
+            {
+              "type": "ExpressionStatement",
+              "start": 40,
+              "end": 43,
+              "loc": {
+                "start": {
+                  "line": 7,
+                  "column": 2
+                },
+                "end": {
+                  "line": 7,
+                  "column": 5
+                }
+              },
+              "expression": {
+                "type": "CallExpression",
+                "start": 40,
+                "end": 43,
+                "loc": {
+                  "start": {
+                    "line": 7,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 7,
+                    "column": 5
+                  }
+                },
+                "callee": {
+                  "type": "Identifier",
+                  "start": 40,
+                  "end": 41,
+                  "loc": {
+                    "start": {
+                      "line": 7,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 7,
+                      "column": 3
+                    },
+                    "identifierName": "y"
+                  },
+                  "name": "y"
+                },
+                "arguments": []
+              }
+            }
+          ],
+          "directives": [],
+          "extra": {
+            "curly": false
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/lightscript/paren-free/multiline-cond/actual.js
+++ b/test/fixtures/lightscript/paren-free/multiline-cond/actual.js
@@ -1,0 +1,3 @@
+if true
+  and true:
+    x()

--- a/test/fixtures/lightscript/paren-free/multiline-cond/expected.json
+++ b/test/fixtures/lightscript/paren-free/multiline-cond/expected.json
@@ -1,0 +1,167 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 27,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 7
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 27,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 7
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "IfStatement",
+        "start": 0,
+        "end": 27,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 7
+          }
+        },
+        "test": {
+          "type": "LogicalExpression",
+          "start": 3,
+          "end": 18,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 3
+            },
+            "end": {
+              "line": 2,
+              "column": 10
+            }
+          },
+          "left": {
+            "type": "BooleanLiteral",
+            "start": 3,
+            "end": 7,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 3
+              },
+              "end": {
+                "line": 1,
+                "column": 7
+              }
+            },
+            "value": true
+          },
+          "operator": "&&",
+          "right": {
+            "type": "BooleanLiteral",
+            "start": 14,
+            "end": 18,
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 6
+              },
+              "end": {
+                "line": 2,
+                "column": 10
+              }
+            },
+            "value": true
+          }
+        },
+        "consequent": {
+          "type": "BlockStatement",
+          "start": 18,
+          "end": 27,
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 10
+            },
+            "end": {
+              "line": 3,
+              "column": 7
+            }
+          },
+          "body": [
+            {
+              "type": "ExpressionStatement",
+              "start": 24,
+              "end": 27,
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 4
+                },
+                "end": {
+                  "line": 3,
+                  "column": 7
+                }
+              },
+              "expression": {
+                "type": "CallExpression",
+                "start": 24,
+                "end": 27,
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 7
+                  }
+                },
+                "callee": {
+                  "type": "Identifier",
+                  "start": 24,
+                  "end": 25,
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 4
+                    },
+                    "end": {
+                      "line": 3,
+                      "column": 5
+                    },
+                    "identifierName": "x"
+                  },
+                  "name": "x"
+                },
+                "arguments": []
+              }
+            }
+          ],
+          "directives": [],
+          "extra": {
+            "curly": false
+          }
+        },
+        "alternate": null
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/lightscript/whitespace/do-while-dedented/actual.js
+++ b/test/fixtures/lightscript/whitespace/do-while-dedented/actual.js
@@ -1,0 +1,4 @@
+if false:
+  do:
+    x()
+while false

--- a/test/fixtures/lightscript/whitespace/do-while-dedented/options.json
+++ b/test/fixtures/lightscript/whitespace/do-while-dedented/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Mismatched indent. (4:0)"
+}

--- a/test/fixtures/lightscript/whitespace/nested-if-then-elif/actual.js
+++ b/test/fixtures/lightscript/whitespace/nested-if-then-elif/actual.js
@@ -1,0 +1,6 @@
+q =
+  if x:
+    if y:
+      y(x)
+  elif z:
+    z()

--- a/test/fixtures/lightscript/whitespace/nested-if-then-elif/expected.json
+++ b/test/fixtures/lightscript/whitespace/nested-if-then-elif/expected.json
@@ -1,0 +1,362 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 50,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 6,
+      "column": 7
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 50,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 6,
+        "column": 7
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "VariableDeclaration",
+        "start": 0,
+        "end": 50,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 6,
+            "column": 7
+          }
+        },
+        "kind": "const",
+        "extra": {
+          "implicit": true
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 0,
+            "end": 50,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 0
+              },
+              "end": {
+                "line": 6,
+                "column": 7
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 0,
+              "end": 1,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 1
+                },
+                "identifierName": "q"
+              },
+              "name": "q"
+            },
+            "init": {
+              "type": "IfExpression",
+              "start": 6,
+              "end": 50,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 6,
+                  "column": 7
+                }
+              },
+              "test": {
+                "type": "Identifier",
+                "start": 9,
+                "end": 10,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 6
+                  },
+                  "identifierName": "x"
+                },
+                "name": "x"
+              },
+              "consequent": {
+                "type": "BlockStatement",
+                "start": 10,
+                "end": 32,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 6
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 10
+                  }
+                },
+                "body": [
+                  {
+                    "type": "IfStatement",
+                    "start": 16,
+                    "end": 32,
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 4
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 10
+                      }
+                    },
+                    "test": {
+                      "type": "Identifier",
+                      "start": 19,
+                      "end": 20,
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 7
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 8
+                        },
+                        "identifierName": "y"
+                      },
+                      "name": "y"
+                    },
+                    "consequent": {
+                      "type": "BlockStatement",
+                      "start": 20,
+                      "end": 32,
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 8
+                        },
+                        "end": {
+                          "line": 4,
+                          "column": 10
+                        }
+                      },
+                      "body": [
+                        {
+                          "type": "ExpressionStatement",
+                          "start": 28,
+                          "end": 32,
+                          "loc": {
+                            "start": {
+                              "line": 4,
+                              "column": 6
+                            },
+                            "end": {
+                              "line": 4,
+                              "column": 10
+                            }
+                          },
+                          "expression": {
+                            "type": "CallExpression",
+                            "start": 28,
+                            "end": 32,
+                            "loc": {
+                              "start": {
+                                "line": 4,
+                                "column": 6
+                              },
+                              "end": {
+                                "line": 4,
+                                "column": 10
+                              }
+                            },
+                            "callee": {
+                              "type": "Identifier",
+                              "start": 28,
+                              "end": 29,
+                              "loc": {
+                                "start": {
+                                  "line": 4,
+                                  "column": 6
+                                },
+                                "end": {
+                                  "line": 4,
+                                  "column": 7
+                                },
+                                "identifierName": "y"
+                              },
+                              "name": "y"
+                            },
+                            "arguments": [
+                              {
+                                "type": "Identifier",
+                                "start": 30,
+                                "end": 31,
+                                "loc": {
+                                  "start": {
+                                    "line": 4,
+                                    "column": 8
+                                  },
+                                  "end": {
+                                    "line": 4,
+                                    "column": 9
+                                  },
+                                  "identifierName": "x"
+                                },
+                                "name": "x"
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "directives": [],
+                      "extra": {
+                        "curly": false
+                      }
+                    },
+                    "alternate": null
+                  }
+                ],
+                "directives": [],
+                "extra": {
+                  "curly": false
+                }
+              },
+              "alternate": {
+                "type": "IfExpression",
+                "start": 35,
+                "end": 50,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 7
+                  }
+                },
+                "test": {
+                  "type": "Identifier",
+                  "start": 40,
+                  "end": 41,
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 8
+                    },
+                    "identifierName": "z"
+                  },
+                  "name": "z"
+                },
+                "consequent": {
+                  "type": "BlockStatement",
+                  "start": 41,
+                  "end": 50,
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 8
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 7
+                    }
+                  },
+                  "body": [
+                    {
+                      "type": "ExpressionStatement",
+                      "start": 47,
+                      "end": 50,
+                      "loc": {
+                        "start": {
+                          "line": 6,
+                          "column": 4
+                        },
+                        "end": {
+                          "line": 6,
+                          "column": 7
+                        }
+                      },
+                      "expression": {
+                        "type": "CallExpression",
+                        "start": 47,
+                        "end": 50,
+                        "loc": {
+                          "start": {
+                            "line": 6,
+                            "column": 4
+                          },
+                          "end": {
+                            "line": 6,
+                            "column": 7
+                          }
+                        },
+                        "callee": {
+                          "type": "Identifier",
+                          "start": 47,
+                          "end": 48,
+                          "loc": {
+                            "start": {
+                              "line": 6,
+                              "column": 4
+                            },
+                            "end": {
+                              "line": 6,
+                              "column": 5
+                            },
+                            "identifierName": "z"
+                          },
+                          "name": "z"
+                        },
+                        "arguments": []
+                      }
+                    }
+                  ],
+                  "directives": [],
+                  "extra": {
+                    "curly": false
+                  }
+                },
+                "alternate": null
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "directives": []
+  }
+}

--- a/test/fixtures/lightscript/whitespace/nested-if-then-else/actual.js
+++ b/test/fixtures/lightscript/whitespace/nested-if-then-else/actual.js
@@ -1,0 +1,5 @@
+if x:
+  if y:
+    y(x)
+else:
+  z()

--- a/test/fixtures/lightscript/whitespace/nested-if-then-else/expected.json
+++ b/test/fixtures/lightscript/whitespace/nested-if-then-else/expected.json
@@ -1,0 +1,276 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 34,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 5,
+      "column": 5
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 34,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 5,
+        "column": 5
+      }
+    },
+    "sourceType": "script",
+    "body": [
+      {
+        "type": "IfStatement",
+        "start": 0,
+        "end": 34,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 5,
+            "column": 5
+          }
+        },
+        "test": {
+          "type": "Identifier",
+          "start": 3,
+          "end": 4,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 3
+            },
+            "end": {
+              "line": 1,
+              "column": 4
+            },
+            "identifierName": "x"
+          },
+          "name": "x"
+        },
+        "consequent": {
+          "type": "BlockStatement",
+          "start": 4,
+          "end": 22,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 4
+            },
+            "end": {
+              "line": 3,
+              "column": 8
+            }
+          },
+          "body": [
+            {
+              "type": "IfStatement",
+              "start": 8,
+              "end": 22,
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 8
+                }
+              },
+              "test": {
+                "type": "Identifier",
+                "start": 11,
+                "end": 12,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 6
+                  },
+                  "identifierName": "y"
+                },
+                "name": "y"
+              },
+              "consequent": {
+                "type": "BlockStatement",
+                "start": 12,
+                "end": 22,
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 6
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 8
+                  }
+                },
+                "body": [
+                  {
+                    "type": "ExpressionStatement",
+                    "start": 18,
+                    "end": 22,
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 4
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 8
+                      }
+                    },
+                    "expression": {
+                      "type": "CallExpression",
+                      "start": 18,
+                      "end": 22,
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 4
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 8
+                        }
+                      },
+                      "callee": {
+                        "type": "Identifier",
+                        "start": 18,
+                        "end": 19,
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 4
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 5
+                          },
+                          "identifierName": "y"
+                        },
+                        "name": "y"
+                      },
+                      "arguments": [
+                        {
+                          "type": "Identifier",
+                          "start": 20,
+                          "end": 21,
+                          "loc": {
+                            "start": {
+                              "line": 3,
+                              "column": 6
+                            },
+                            "end": {
+                              "line": 3,
+                              "column": 7
+                            },
+                            "identifierName": "x"
+                          },
+                          "name": "x"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "directives": [],
+                "extra": {
+                  "curly": false
+                }
+              },
+              "alternate": null
+            }
+          ],
+          "directives": [],
+          "extra": {
+            "curly": false
+          }
+        },
+        "alternate": {
+          "type": "BlockStatement",
+          "start": 27,
+          "end": 34,
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 4
+            },
+            "end": {
+              "line": 5,
+              "column": 5
+            }
+          },
+          "body": [
+            {
+              "type": "ExpressionStatement",
+              "start": 31,
+              "end": 34,
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 2
+                },
+                "end": {
+                  "line": 5,
+                  "column": 5
+                }
+              },
+              "expression": {
+                "type": "CallExpression",
+                "start": 31,
+                "end": 34,
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 5
+                  }
+                },
+                "callee": {
+                  "type": "Identifier",
+                  "start": 31,
+                  "end": 32,
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 3
+                    },
+                    "identifierName": "z"
+                  },
+                  "name": "z"
+                },
+                "arguments": []
+              }
+            }
+          ],
+          "directives": [],
+          "extra": {
+            "curly": false
+          }
+        }
+      }
+    ],
+    "directives": []
+  }
+}


### PR DESCRIPTION
- Unifies statement and expression versions of "if"
- Makes a newline after an `else` illegal, suggesting a colon instead. 
- Allows if-expressions of the form `if cond: result else alt`, (note that the `else` does not have a colon). 
- Fixes the rather bad significant-indentation bug reported by @wcjohnson
- Includes a mostly-unrelated change to do-while that enforces indent consistency. 
- Makes a newline after `if`, `switch`, `with`, or `while` illegal (eg; `if\n  cond: result` is illegal) to fix [an ambiguity](http://www.lightscript.org/docs/#colons-if-and-types) 