### PR TITLE
Remove bitwise operators

### DIFF
--- a/src/parser/expression.js
+++ b/src/parser/expression.js
@@ -246,6 +246,11 @@ pp.parseExprOp = function(left, leftStartPos, leftStartLoc, minPrec, noIn) {
     }
   }
 
+  if (this.hasPlugin("lightscript") && this.isBitwiseOp()) {
+    this.unexpected(null, "Bitwise operators have been disabled in LightScript. " +
+      "Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`).");
+  }
+
   const prec = this.state.type.binop;
   if (prec != null && (!noIn || !this.match(tt._in))) {
     if (prec > minPrec) {

--- a/src/plugins/lightscript.js
+++ b/src/plugins/lightscript.js
@@ -544,6 +544,15 @@ pp.tryParseNamedArrowDeclaration = function () {
   return node;
 };
 
+pp.isBitwiseOp = function () {
+  return (
+    this.match(tt.bitwiseOR) ||
+    this.match(tt.bitwiseAND) ||
+    this.match(tt.bitwiseXOR) ||
+    this.match(tt.bitShift)
+  );
+};
+
 
 export default function (instance) {
 

--- a/test/fixtures/core/uncategorised/156/options.lightscript.json
+++ b/test/fixtures/core/uncategorised/156/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:2)"
+}

--- a/test/fixtures/core/uncategorised/157/options.lightscript.json
+++ b/test/fixtures/core/uncategorised/157/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:2)"
+}

--- a/test/fixtures/core/uncategorised/158/options.lightscript.json
+++ b/test/fixtures/core/uncategorised/158/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:2)"
+}

--- a/test/fixtures/core/uncategorised/170/options.lightscript.json
+++ b/test/fixtures/core/uncategorised/170/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:2)"
+}

--- a/test/fixtures/core/uncategorised/171/options.lightscript.json
+++ b/test/fixtures/core/uncategorised/171/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:2)"
+}

--- a/test/fixtures/core/uncategorised/172/options.lightscript.json
+++ b/test/fixtures/core/uncategorised/172/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:2)"
+}

--- a/test/fixtures/core/uncategorised/184/options.lightscript.json
+++ b/test/fixtures/core/uncategorised/184/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:2)"
+}

--- a/test/fixtures/core/uncategorised/185/options.lightscript.json
+++ b/test/fixtures/core/uncategorised/185/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:2)"
+}

--- a/test/fixtures/core/uncategorised/186/options.lightscript.json
+++ b/test/fixtures/core/uncategorised/186/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:2)"
+}

--- a/test/fixtures/core/uncategorised/187/options.lightscript.json
+++ b/test/fixtures/core/uncategorised/187/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:2)"
+}

--- a/test/fixtures/core/uncategorised/188/options.lightscript.json
+++ b/test/fixtures/core/uncategorised/188/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:2)"
+}

--- a/test/fixtures/core/uncategorised/189/options.lightscript.json
+++ b/test/fixtures/core/uncategorised/189/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:2)"
+}

--- a/test/fixtures/core/uncategorised/190/options.lightscript.json
+++ b/test/fixtures/core/uncategorised/190/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:2)"
+}

--- a/test/fixtures/core/uncategorised/196/options.lightscript.json
+++ b/test/fixtures/core/uncategorised/196/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:7)"
+}

--- a/test/fixtures/esprima/expression-binary-bitwise/migrated_0000/options.lightscript.json
+++ b/test/fixtures/esprima/expression-binary-bitwise/migrated_0000/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:2)"
+}

--- a/test/fixtures/esprima/expression-binary-bitwise/migrated_0001/options.lightscript.json
+++ b/test/fixtures/esprima/expression-binary-bitwise/migrated_0001/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:2)"
+}

--- a/test/fixtures/esprima/expression-binary-bitwise/migrated_0002/options.lightscript.json
+++ b/test/fixtures/esprima/expression-binary-bitwise/migrated_0002/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:2)"
+}

--- a/test/fixtures/esprima/expression-binary-logical/migrated_0005/options.lightscript.json
+++ b/test/fixtures/esprima/expression-binary-logical/migrated_0005/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:7)"
+}

--- a/test/fixtures/esprima/expression-binary/migrated_0011/options.lightscript.json
+++ b/test/fixtures/esprima/expression-binary/migrated_0011/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:2)"
+}

--- a/test/fixtures/esprima/expression-binary/migrated_0012/options.lightscript.json
+++ b/test/fixtures/esprima/expression-binary/migrated_0012/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:2)"
+}

--- a/test/fixtures/esprima/expression-binary/migrated_0013/options.lightscript.json
+++ b/test/fixtures/esprima/expression-binary/migrated_0013/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:2)"
+}

--- a/test/fixtures/esprima/expression-binary/migrated_0014/options.lightscript.json
+++ b/test/fixtures/esprima/expression-binary/migrated_0014/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:2)"
+}

--- a/test/fixtures/esprima/expression-binary/migrated_0015/options.lightscript.json
+++ b/test/fixtures/esprima/expression-binary/migrated_0015/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:2)"
+}

--- a/test/fixtures/esprima/expression-binary/migrated_0016/options.lightscript.json
+++ b/test/fixtures/esprima/expression-binary/migrated_0016/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:2)"
+}

--- a/test/fixtures/esprima/expression-binary/migrated_0017/options.lightscript.json
+++ b/test/fixtures/esprima/expression-binary/migrated_0017/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:2)"
+}

--- a/test/fixtures/esprima/expression-bitwise-shift/migrated_0000/options.lightscript.json
+++ b/test/fixtures/esprima/expression-bitwise-shift/migrated_0000/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:2)"
+}

--- a/test/fixtures/esprima/expression-bitwise-shift/migrated_0001/options.lightscript.json
+++ b/test/fixtures/esprima/expression-bitwise-shift/migrated_0001/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:2)"
+}

--- a/test/fixtures/esprima/expression-bitwise-shift/migrated_0002/options.lightscript.json
+++ b/test/fixtures/esprima/expression-bitwise-shift/migrated_0002/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:2)"
+}

--- a/test/fixtures/esprima/expression-complex/migrated_0000/options.lightscript.json
+++ b/test/fixtures/esprima/expression-complex/migrated_0000/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:12)"
+}

--- a/test/fixtures/esprima/expression-grouping/migrated_0001/options.lightscript.json
+++ b/test/fixtures/esprima/expression-grouping/migrated_0001/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (1:6)"
+}

--- a/test/fixtures/flow/regression/issue-2083/options.lightscript.json
+++ b/test/fixtures/flow/regression/issue-2083/options.lightscript.json
@@ -1,0 +1,3 @@
+{
+  "throws": "Bitwise operators have been disabled in LightScript. Use the stdlib functions instead (eg; `bitwiseAnd(a, b)`). (4:33)"
+}

--- a/test/utils/runFixtureTests.js
+++ b/test/utils/runFixtureTests.js
@@ -126,6 +126,11 @@ function save(test, ast) {
   RegExp.prototype.toJSON = toJSON;
 }
 
+function saveLscErr(test, msg) {
+  const lscOptionsLoc = test.actual.loc.replace("actual.js", "options.lightscript.json");
+  require("fs").writeFileSync(lscOptionsLoc, JSON.stringify({ throws: msg }, null, "  "));
+}
+
 function runTest(test, parseFunction) {
   var opts = test.options;
   opts.locations = true;
@@ -146,7 +151,7 @@ function runTest(test, parseFunction) {
         throw err;
       }
     }
-
+    // saveLscErr(test, err.message);
     throw err;
   }
 


### PR DESCRIPTION
Removes `&`, `|`, `^`, `<<` ,`>>`, `>>>` from the binary parsing algo with a slightly helpful error message. 

Frees them up for other purposes in a consistent fashion. Eg; `~` (already appropriated) and `|` for pattern matching. 

No plans as of yet for `&` or the bitshifts, I have an idea for `^` but not sure about it yet. 